### PR TITLE
feat: publish package to private npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ workflows:
           name: Release NPM
           context:
             - team-unify
+            - analysis_unify_npm_publish
           requires:
             - Scan repository for secrets
             - Security Scans

--- a/.releaserc
+++ b/.releaserc
@@ -5,6 +5,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
     [
       "@semantic-release/github",
       {


### PR DESCRIPTION
### What does this do

Add npm publishing to `semantic-release` to publish to the npmjs registry as a private package.

UNIFY-870