### PR TITLE
fix: version for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snyk/package-manager-detection",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "description": "A library for detecting manifest files and detecting associated package managers",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
### What does this do

This updates the `package.json` `version` field to be `0.0.0-development` which is recommended by `semantic-release` in [their documentation](https://semantic-release.gitbook.io/semantic-release/support/faq#why-is-the-package.jsons-version-not-updated-in-my-repository).