### PR TITLE
fix: npm publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
           name: Release NPM
           context:
             - team-unify
-            - analysis_unify_npm_publish
+            - nodejs-lib-release
           requires:
             - Scan repository for secrets
             - Security Scans

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
-# package-manager-detection
+![Snyk logo](https://snyk.io/style/asset/logo/snyk-print.svg)
+
+***
+
+Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
+
+| :information_source: This repository is only a package to be used with the Snyk CLI tool. To use this package to test and fix vulnerabilities in your project, install the Snyk CLI tool first. Head over to [snyk.io](https://github.com/snyk/snyk) to get started. |
+| --- |
+
+## Snyk Package Manager Detection
 
 A library for detecting manifest files and detecting associated package managers.


### PR DESCRIPTION
### What does this do

- Switches the npm publishing user to be consistent with other cli related npm packages.
- Updates the README to include Snyk cli messaging.