### PR TITLE
feat: add package.json validation to skip unity files

### DIFF
--- a/src/detectors.spec.ts
+++ b/src/detectors.spec.ts
@@ -16,6 +16,14 @@ const nxTestContent = realFs.readFileSync(
   path.join(__dirname, '../testdata/nx-project.json'),
   'utf-8',
 );
+const unityPackageJson = realFs.readFileSync(
+  path.join(__dirname, '../testdata/unity-package.json'),
+  'utf-8',
+);
+const npmPackageJson = realFs.readFileSync(
+  path.join(__dirname, '../testdata/npm-package.json'),
+  'utf-8',
+);
 
 jest.mock('fs');
 
@@ -247,6 +255,31 @@ describe('detectPackageManagerFromFile', () => {
       const result = detectPackageManagerFromFile('/path/to/project.json');
       expect(result).toBe('nuget');
       expect(mockExistsSync).toHaveBeenCalledWith('/path/to/project.json');
+    });
+  });
+
+  describe('package.json content validation', () => {
+    it('should detect npm for a typical Node package.json when file exists', () => {
+      mockExistsSync.mockReturnValueOnce(true);
+      mockReadFileSync.mockReturnValueOnce(npmPackageJson);
+
+      const result = detectPackageManagerFromFile('/any/path/package.json');
+      expect(result).toBe('npm');
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        '/any/path/package.json',
+        'utf-8',
+      );
+    });
+
+    it('should not classify Unity package.json as npm and throw', () => {
+      mockExistsSync.mockReturnValueOnce(true);
+      mockReadFileSync.mockReturnValueOnce(unityPackageJson);
+
+      expect(() =>
+        detectPackageManagerFromFile('/game/Assets/package.json'),
+      ).toThrow(
+        'Could not detect package manager for file: /game/Assets/package.json',
+      );
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export enum SUPPORTED_MANIFEST_FILES {
 
 export type PackageManagerDetector = {
   packageManager: SupportedPackageManager;
+  /** Returns true if the content is valid for the package manager */
   validateContent?: (content: string) => boolean;
 };
 
@@ -76,7 +77,24 @@ export const DETECTABLE_PACKAGE_MANAGERS = new Map<
   [SUPPORTED_MANIFEST_FILES.BUILD_SBT, [{ packageManager: 'sbt' }]],
   [SUPPORTED_MANIFEST_FILES.YARN_LOCK, [{ packageManager: 'yarn' }]],
   [SUPPORTED_MANIFEST_FILES.PNPM_LOCK, [{ packageManager: 'pnpm' }]],
-  [SUPPORTED_MANIFEST_FILES.PACKAGE_JSON, [{ packageManager: 'npm' }]],
+  [
+    SUPPORTED_MANIFEST_FILES.PACKAGE_JSON,
+    [
+      {
+        packageManager: 'npm',
+        validateContent: (content: string): boolean => {
+          try {
+            const json = JSON.parse(content);
+            // Unity field is recommended, name and version are the only required fields in unity package.json
+            // but these are also required fields in npm package.json so not exhaustive check
+            return !(json.unity || json.unityRelease);
+          } catch {
+            return true;
+          }
+        },
+      },
+    ],
+  ],
   [SUPPORTED_MANIFEST_FILES.PIPFILE, [{ packageManager: 'pip' }]],
   [SUPPORTED_MANIFEST_FILES.SETUP_PY, [{ packageManager: 'pip' }]],
   [SUPPORTED_MANIFEST_FILES.REQUIREMENTS_TXT, [{ packageManager: 'pip' }]],

--- a/testdata/npm-package.json
+++ b/testdata/npm-package.json
@@ -1,0 +1,8 @@
+{
+    "name": "example-app",
+    "version": "1.0.0",
+    "description": "Example Node project for tests",
+    "dependencies": {
+        "react": "^18.0.0"
+    }
+}

--- a/testdata/unity-package.json
+++ b/testdata/unity-package.json
@@ -1,0 +1,11 @@
+{
+    "name": "com.unity.textmeshpro",
+    "displayName": "TextMeshPro",
+    "version": "3.0.0",
+    "unity": "2021.3",
+    "description": "Unity package for advanced text rendering.",
+    "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+    },
+    "unityRelease": "1.0.0"
+}


### PR DESCRIPTION
Skip unity package.json when encountered as we do not support UPM and otherwise would be scanned as NPM. 

Checking for unity and unityRelease fields as these are specific to unity. Unfortunatley these fields are only recommended not required but they are the only ones that do not overlap with NPM's package.json fields.

Currently unity package.json are scanning as NPM and showing vulns as there are malicious packages on NPM that have the same name as valid unity packages.

https://snyksec.atlassian.net/browse/OSM-3068
https://snyk.slack.com/archives/C069RBK010B/p1753336449187089